### PR TITLE
Support read/write dynamic fields, check difference before updating

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>9</version>
-    </parent>
-
-    <groupId>com.github.fhuss</groupId>
+    <groupId>com.lambdacloud.streaming</groupId>
     <artifactId>storm-elasticsearch</artifactId>
     <version>0.3.0</version>
     <name>Storm Trident Elasticsearch</name>
@@ -29,37 +23,12 @@
         <commons-lang3.version>3.3</commons-lang3.version>
     </properties>
 
-    <licenses>
-        <license>
-            <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-        </license>
-    </licenses>
-
-    <developers>
-        <developer>
-            <id>fhuss</id>
-            <name>Florian Hussonnois</name>
-            <email>florian.hussonnois@gmail.com</email>
-            <url>https://github.com/fhussonnois</url>
-            <roles>
-                <role>developer</role>
-            </roles>
-        </developer>
-    </developers>
-
-    <scm>
-        <connection>scm:git:git@github.com:fhussonnois/storm-trident-elasticsearch.git</connection>
-        <developerConnection>scm:git:git@github.com:fhussonnois/storm-trident-elasticsearch.git</developerConnection>
-        <url>git@github.com:fhussonnois/storm-trident-elasticsearch.git</url>
-    </scm>
-
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.3</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -79,7 +48,6 @@
             <groupId>org.apache.storm</groupId>
             <artifactId>storm-core</artifactId>
             <version>${storm.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.lambdacloud.streaming</groupId>
+    <groupId>com.lambdacloud.realtime.streaming</groupId>
     <artifactId>storm-elasticsearch</artifactId>
-    <version>0.3.0</version>
+    <version>0.3.0.1</version>
     <name>Storm Trident Elasticsearch</name>
     <description>Trident API implementation for Elasticsearch</description>
 
@@ -22,6 +22,13 @@
         <guava.version>16.0.1</guava.version>
         <commons-lang3.version>3.3</commons-lang3.version>
     </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
 
     <build>
         <plugins>

--- a/src/main/java/com/github/fhuss/storm/elasticsearch/state/ESIndexMapState.java
+++ b/src/main/java/com/github/fhuss/storm/elasticsearch/state/ESIndexMapState.java
@@ -21,7 +21,6 @@ import storm.trident.state.State;
 import storm.trident.state.StateFactory;
 import storm.trident.state.StateType;
 import storm.trident.state.TransactionalValue;
-import storm.trident.state.map.CachedMap;
 import storm.trident.state.map.IBackingMap;
 import storm.trident.state.map.MapState;
 import storm.trident.state.map.NonTransactionalMap;
@@ -108,7 +107,7 @@ public class ESIndexMapState<T> implements IBackingMap<T> {
         public State makeState(Map conf, IMetricsContext iMetricsContext, int i, int i2) {
             Options options = new Options(conf);
             ESIndexMapState<OpaqueValue<T>> mapState = new ESIndexMapState<>(clientFactory.makeClient(conf), serializer, new BulkResponseHandler.LoggerResponseHandler(), options.reportError());
-            MapState ms  = OpaqueMap.build(new CachedMap(mapState, options.getCachedMapSize()));
+            MapState ms  = OpaqueMap.build(new EnCachedMap(mapState, options.getCachedMapSize()));
             return new SnapshottableMap<OpaqueValue<T>>(ms, new Values(options.getGlobalKey()));
         }
     }
@@ -123,7 +122,7 @@ public class ESIndexMapState<T> implements IBackingMap<T> {
         public State makeState(Map conf, IMetricsContext iMetricsContext, int i, int i2) {
             Options options = new Options(conf);
             ESIndexMapState<TransactionalValue<T>> mapState = new ESIndexMapState<>(clientFactory.makeClient(conf), serializer, new BulkResponseHandler.LoggerResponseHandler(), options.reportError());
-            MapState<T> ms  = TransactionalMap.build(new CachedMap(mapState, options.getCachedMapSize()));
+            MapState<T> ms  = TransactionalMap.build(new EnCachedMap(mapState, options.getCachedMapSize()));
             Values snapshotKey = new Values(options.getGlobalKey());
             return new SnapshottableMap<>(ms, snapshotKey);
         }
@@ -139,7 +138,7 @@ public class ESIndexMapState<T> implements IBackingMap<T> {
         public State makeState(Map conf, IMetricsContext iMetricsContext, int i, int i2) {
             Options options = new Options(conf);
             ESIndexMapState<T> mapState = new ESIndexMapState<>(clientFactory.makeClient(conf), serializer, new BulkResponseHandler.LoggerResponseHandler(), options.reportError());
-            MapState<T> ms  = NonTransactionalMap.build(new CachedMap<>(mapState, options.getCachedMapSize()));
+            MapState<T> ms  = NonTransactionalMap.build(new EnCachedMap<>(mapState, options.getCachedMapSize()));
             return new SnapshottableMap<>(ms, new Values(options.getGlobalKey()));
         }
     }

--- a/src/main/java/com/github/fhuss/storm/elasticsearch/state/ESIndexMapState.java
+++ b/src/main/java/com/github/fhuss/storm/elasticsearch/state/ESIndexMapState.java
@@ -107,7 +107,7 @@ public class ESIndexMapState<T> implements IBackingMap<T> {
         public State makeState(Map conf, IMetricsContext iMetricsContext, int i, int i2) {
             Options options = new Options(conf);
             ESIndexMapState<OpaqueValue<T>> mapState = new ESIndexMapState<>(clientFactory.makeClient(conf), serializer, new BulkResponseHandler.LoggerResponseHandler(), options.reportError());
-            MapState ms  = OpaqueMap.build(new EnCachedMap(mapState, options.getCachedMapSize()));
+            MapState ms  = OpaqueMap.build(new ExtCachedMap(mapState, options.getCachedMapSize()));
             return new SnapshottableMap<OpaqueValue<T>>(ms, new Values(options.getGlobalKey()));
         }
     }
@@ -122,7 +122,7 @@ public class ESIndexMapState<T> implements IBackingMap<T> {
         public State makeState(Map conf, IMetricsContext iMetricsContext, int i, int i2) {
             Options options = new Options(conf);
             ESIndexMapState<TransactionalValue<T>> mapState = new ESIndexMapState<>(clientFactory.makeClient(conf), serializer, new BulkResponseHandler.LoggerResponseHandler(), options.reportError());
-            MapState<T> ms  = TransactionalMap.build(new EnCachedMap(mapState, options.getCachedMapSize()));
+            MapState<T> ms  = TransactionalMap.build(new ExtCachedMap(mapState, options.getCachedMapSize()));
             Values snapshotKey = new Values(options.getGlobalKey());
             return new SnapshottableMap<>(ms, snapshotKey);
         }
@@ -138,7 +138,7 @@ public class ESIndexMapState<T> implements IBackingMap<T> {
         public State makeState(Map conf, IMetricsContext iMetricsContext, int i, int i2) {
             Options options = new Options(conf);
             ESIndexMapState<T> mapState = new ESIndexMapState<>(clientFactory.makeClient(conf), serializer, new BulkResponseHandler.LoggerResponseHandler(), options.reportError());
-            MapState<T> ms  = NonTransactionalMap.build(new EnCachedMap<>(mapState, options.getCachedMapSize()));
+            MapState<T> ms  = NonTransactionalMap.build(new ExtCachedMap<>(mapState, options.getCachedMapSize()));
             return new SnapshottableMap<>(ms, new Values(options.getGlobalKey()));
         }
     }

--- a/src/main/java/com/github/fhuss/storm/elasticsearch/state/EnCachedMap.java
+++ b/src/main/java/com/github/fhuss/storm/elasticsearch/state/EnCachedMap.java
@@ -1,0 +1,80 @@
+package com.github.fhuss.storm.elasticsearch.state;
+
+import storm.trident.state.map.IBackingMap;
+import storm.trident.util.LRUMap;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Modified from storm's {@ref storm.trident.state.map.CachedMap}. The different is this one will not update
+ * unchanged state
+ * @author sky4star
+ */
+public class EnCachedMap<T> implements IBackingMap<T> {
+  LRUMap<List<Object>, T> _cache;
+  IBackingMap<T> _delegate;
+
+  public EnCachedMap(IBackingMap<T> delegate, int cacheSize) {
+    _cache = new LRUMap<List<Object>, T>(cacheSize);
+    _delegate = delegate;
+  }
+
+  @Override
+  public List<T> multiGet(List<List<Object>> keys) {
+    Map<List<Object>, T> results = new HashMap<List<Object>, T>();
+    List<List<Object>> toGet = new ArrayList<List<Object>>();
+    for (List<Object> key : keys) {
+      if (_cache.containsKey(key)) {
+        results.put(key, _cache.get(key));
+      } else {
+        toGet.add(key);
+      }
+    }
+
+    List<T> fetchedVals = _delegate.multiGet(toGet);
+    for (int i = 0; i < toGet.size(); i++) {
+      List<Object> key = toGet.get(i);
+      T val = fetchedVals.get(i);
+      _cache.put(key, val);
+      results.put(key, val);
+    }
+
+    List<T> ret = new ArrayList<T>(keys.size());
+    for (List<Object> key : keys) {
+      ret.add(results.get(key));
+    }
+    return ret;
+  }
+
+  @Override
+  public void multiPut(List<List<Object>> keys, List<T> values) {
+    // Check if the same before updating
+    List<List<Object>> toUpdateKeys = new ArrayList<>();
+    List<T> toUpdateValues = new ArrayList<>();
+    for (int i = 0; i < keys.size(); i++) {
+      List<Object> key = keys.get(i);
+      T value = values.get(i);
+      if (_cache.get(key) == null
+          || !_cache.get(key).equals(value)) {
+        toUpdateKeys.add(key);
+        toUpdateValues.add(value);
+      }
+    }
+
+    // Only cache and update the different ones
+    if (toUpdateKeys.size() > 0 && toUpdateKeys.size() == toUpdateValues.size()) {
+      cache(toUpdateKeys, toUpdateValues);
+      _delegate.multiPut(toUpdateKeys, toUpdateValues);
+    }
+  }
+
+  private void cache(List<List<Object>> keys, List<T> values) {
+    for (int i = 0; i < keys.size(); i++) {
+      _cache.put(keys.get(i), values.get(i));
+    }
+  }
+}

--- a/src/main/java/com/github/fhuss/storm/elasticsearch/state/ExtCachedMap.java
+++ b/src/main/java/com/github/fhuss/storm/elasticsearch/state/ExtCachedMap.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2015. LambdaCloud
+ * All rights reserved.
+ */
+
 package com.github.fhuss.storm.elasticsearch.state;
 
 import storm.trident.state.map.IBackingMap;
@@ -14,11 +19,11 @@ import java.util.Map;
  * unchanged state
  * @author sky4star
  */
-public class EnCachedMap<T> implements IBackingMap<T> {
+public class ExtCachedMap<T> implements IBackingMap<T> {
   LRUMap<List<Object>, T> _cache;
   IBackingMap<T> _delegate;
 
-  public EnCachedMap(IBackingMap<T> delegate, int cacheSize) {
+  public ExtCachedMap(IBackingMap<T> delegate, int cacheSize) {
     _cache = new LRUMap<List<Object>, T>(cacheSize);
     _delegate = delegate;
   }

--- a/src/main/java/com/github/fhuss/storm/elasticsearch/state/JsonDynamicFields.java
+++ b/src/main/java/com/github/fhuss/storm/elasticsearch/state/JsonDynamicFields.java
@@ -1,0 +1,38 @@
+package com.github.fhuss.storm.elasticsearch.state;
+
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.*;
+
+
+public class JsonDynamicFields extends Object implements Serializable{
+
+  protected Map<String, String> properties = new HashMap<>();
+
+  protected static final ObjectMapper mapper = new ObjectMapper();
+
+  public byte[] serialize() throws IOException {
+    return mapper.writeValueAsBytes(properties);
+  }
+
+  public void deserialize(byte[] bytes) throws IOException {
+    properties = mapper.readValue(bytes, new TypeReference<Map<String, String>>(){});
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    JsonDynamicFields df = (JsonDynamicFields)obj;
+    if (!this.properties.equals(df.properties)) {
+      return false;
+    }
+
+    return true;
+  }
+
+}

--- a/src/main/java/com/github/fhuss/storm/elasticsearch/state/JsonDynamicFields.java
+++ b/src/main/java/com/github/fhuss/storm/elasticsearch/state/JsonDynamicFields.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.Map.*;
 
 
-public class JsonDynamicFields extends Object implements Serializable{
+public class JsonDynamicFields extends Object implements Serializable, Cloneable{
 
   protected Map<String, String> properties = new HashMap<>();
 
@@ -33,6 +33,13 @@ public class JsonDynamicFields extends Object implements Serializable{
     }
 
     return true;
+  }
+
+  @Override
+  public JsonDynamicFields clone() {
+    JsonDynamicFields clone = new JsonDynamicFields();
+    clone.properties.putAll(this.properties);
+    return clone;
   }
 
 }


### PR DESCRIPTION
1. support dynamic fields, you can add any new fields into map named
   properties, it will be flattened as {“field1”:”value1”, …} when
   persisting into Elasticsearch.
2. performance tuning, not update a doc if the content doesn’t change
3. update pom
